### PR TITLE
Created a mediator non wrapped variant with generic query and projection

### DIFF
--- a/AutoMapper/SecureValueConverter.cs
+++ b/AutoMapper/SecureValueConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using AutoMapper;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace CQRSTest.AutoMapper
+{
+    /// <summary>
+    /// Provides a way to decrypt values
+    /// </summary>
+    public class SecureValueConverter : IValueConverter<string, string>
+    {
+        private readonly IDataProtectionProvider _dataProtectionProvider;
+
+        public SecureValueConverter(IDataProtectionProvider dataProtectionProvider)
+        {
+            this._dataProtectionProvider = dataProtectionProvider;
+        }
+
+        public string Convert(string sourceMember, ResolutionContext context)
+        {
+            try
+            {
+                return _dataProtectionProvider.CreateProtector("Secure").Unprotect(sourceMember);
+            }
+            catch (Exception ex)
+            {
+                return sourceMember;
+            }
+        }
+    }
+}

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+﻿using System.Diagnostics;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using CQRSTest.Models;
 using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace CQRSTest.Controllers
 {
@@ -19,9 +16,10 @@ namespace CQRSTest.Controllers
             _logger = logger;
         }
 
-        public async Task<IActionResult> Index([FromServices]IMediator mediator)
+        public async Task<IActionResult> Index([FromServices] IMediator mediator)
         {
-            var viewModel = await SimpleDeviceViewModel.Load(mediator, 1);
+            //var viewModel = await SimpleDeviceViewModel.Load(mediator, 1);
+            var viewModel = await mediator.Send(new DeviceGetByIdRequest<SimpleDeviceViewModel>(1));
             return View();
         }
 

--- a/Data/DatabaseInitializer.cs
+++ b/Data/DatabaseInitializer.cs
@@ -1,18 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Microsoft.AspNetCore.DataProtection;
 
 namespace CQRSTest.Data
 {
     public static class DatabaseInitializer
     {
-        public static void Initialize(DatabaseContext context)
+        public static void Initialize(DatabaseContext context, IDataProtectionProvider dataProtectionProvider)
         {
             var deviceType = new DeviceType
             {
-                Name = "The best device type"
+                Name = "The best device type",
+                FunctionalConfiguration = Configuration.Optional,
+                SecureContent = dataProtectionProvider.CreateProtector("Secure").Protect("Some secure text")
             };
             context.DeviceTypes.Add(deviceType);
 

--- a/Data/DeviceType.cs
+++ b/Data/DeviceType.cs
@@ -1,8 +1,22 @@
 using System.ComponentModel.DataAnnotations.Schema;
 
-public class DeviceType {
+public class DeviceType
+{
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; }
 
     public string Name { get; set; }
+
+    public string SecureContent { get; set; }
+
+    public Configuration TechnicalConfiguration { get; set; }
+
+    public Configuration FunctionalConfiguration { get; set; }
+}
+
+public enum Configuration
+{
+    NotSupported = 0,
+    Optional = 1,
+    Required = 2
 }

--- a/Queries/DeviceGetByIdRequest.cs
+++ b/Queries/DeviceGetByIdRequest.cs
@@ -1,16 +1,11 @@
-using AutoMapper;
 using MediatR;
 
 public class DeviceGetByIdRequest<TResult> : IRequest<TResult>
 {
-    public DeviceGetByIdRequest(
-        int id,
-        IConfigurationProvider mapping)
+    public DeviceGetByIdRequest(int id)
     {
         this.Id = id;
-        this.Mapping = mapping;
     }
 
     public int Id { get; }
-    public IConfigurationProvider Mapping { get; }
 }

--- a/Queries/Handlers/DeviceGetByIdRequestHandler.cs
+++ b/Queries/Handlers/DeviceGetByIdRequestHandler.cs
@@ -28,8 +28,12 @@ namespace CQRSTest.Queries.Handlers
                             .Where(d => d.Id == request.Id);
 
             // Projection
-            return await this._mapper.ProjectTo<TResult>(deviceQuery)
+            var queryResult = await this._mapper.ProjectTo<TResult>(deviceQuery)
                                         .SingleOrDefaultAsync(cancellationToken);
+
+            // We Map here from TResult to TResult, to give a developer the option do do things that are not supported in Projections
+            // See: https://docs.automapper.org/en/stable/Queryable-Extensions.html#supported-mapping-options for items that should be in the TResult to TResult mapping instead of the projection
+            return this._mapper.Map<TResult, TResult>(queryResult);
         }
     }
 }

--- a/Queries/Handlers/DeviceGetByIdRequestHandler.cs
+++ b/Queries/Handlers/DeviceGetByIdRequestHandler.cs
@@ -1,31 +1,35 @@
-﻿using AutoMapper.QueryableExtensions;
-using MediatR;
-using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
 
 namespace CQRSTest.Queries.Handlers
 {
     public class DeviceGetByIdRequestHandler<TResult> : IRequestHandler<DeviceGetByIdRequest<TResult>, TResult>
     {
         private readonly DatabaseContext _context;
+        private readonly IMapper _mapper;
 
-        public DeviceGetByIdRequestHandler(DatabaseContext context)
+        public DeviceGetByIdRequestHandler(
+            DatabaseContext context,
+            IMapper mapper)
         {
             this._context = context;
+            this._mapper = mapper;
         }
 
         public async Task<TResult> Handle(DeviceGetByIdRequest<TResult> request, CancellationToken cancellationToken)
         {
-            return await this._context.Devices
+            // Query
+            var deviceQuery = this._context.Devices
                             .AsNoTracking()
-                            .Where(d => d.Id == request.Id)
-                            .ProjectTo<TResult>(request.Mapping)
-                            .SingleOrDefaultAsync(cancellationToken);
+                            .Where(d => d.Id == request.Id);
+
+            // Projection
+            return await this._mapper.ProjectTo<TResult>(deviceQuery)
+                                        .SingleOrDefaultAsync(cancellationToken);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# CQRSTest
+This is a small proof-of-concept repo for having a dynamic projection based query using automapper and mediatr.
+
+# Explanation
+The intention was to create a projection based variant of the GetById found in many repository examples.
+Projection is used to only retrieve relevant fields from the database.
+In addition, an additional mapping step is done in the RequestHandler to allow a developer to access AutoMapper features that are unsupported in the 'Projection' flow.
+
+Relevant code:
+- Request: [/Queries/DeviceGetByIdRequest.cs](https://github.com/FrankHoogmans/CQRSTest/blob/main/Queries/DeviceGetByIdRequest.cs)
+- Request Handler: [/Queries/Handlers/DeviceGetByIdRequestHandler.cs](https://github.com/FrankHoogmans/CQRSTest/blob/main/Queries/Handlers/DeviceGetByIdRequestHandler.cs)
+- ViewModel and mapping: [/ViewModels/SimpleDeviceViewModel.cs](https://github.com/FrankHoogmans/CQRSTest/blob/main/ViewModels/SimpleDeviceViewModel.cs)
+- Execution of the Request: [/Controllers/HomeController.cs](https://github.com/FrankHoogmans/CQRSTest/blob/main/Controllers/HomeController.cs)
+
+- Plumbing: [/Startup.cs](https://github.com/FrankHoogmans/CQRSTest/blob/main/Startup.cs)

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,4 +1,5 @@
 using AutoMapper.Extensions.ExpressionMapping;
+using CQRSTest.AutoMapper;
 using CQRSTest.Data;
 using CQRSTest.Queries.Handlers;
 using MediatR;

--- a/Startup.cs
+++ b/Startup.cs
@@ -3,6 +3,7 @@ using CQRSTest.Data;
 using CQRSTest.Queries.Handlers;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -27,6 +28,8 @@ namespace CQRSTest
                         .AddDbContext<DatabaseContext>(options => options.UseInMemoryDatabase("CQRSTest"));
 
             services.AddControllersWithViews();
+            services.AddDataProtection();
+            services.AddTransient<SecureValueConverter>();
 
             // Init MediatR
             services.AddMediatR(typeof(Startup).Assembly);
@@ -46,7 +49,8 @@ namespace CQRSTest
             using (var scope = services.BuildServiceProvider().CreateScope())
             {
                 var context = scope.ServiceProvider.GetRequiredService<DatabaseContext>();
-                DatabaseInitializer.Initialize(context);
+                var dataprotectionProvider = scope.ServiceProvider.GetRequiredService<IDataProtectionProvider>();
+                DatabaseInitializer.Initialize(context, dataprotectionProvider);
             }
         }
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using System;
 
 namespace CQRSTest
 {
@@ -28,7 +27,7 @@ namespace CQRSTest
                         .AddDbContext<DatabaseContext>(options => options.UseInMemoryDatabase("CQRSTest"));
 
             services.AddControllersWithViews();
-            
+
             // Init MediatR
             services.AddMediatR(typeof(Startup).Assembly);
 
@@ -40,6 +39,7 @@ namespace CQRSTest
             services.AddAutoMapper(cfg =>
             {
                 cfg.AddExpressionMapping();
+                cfg.AddMaps(typeof(Startup).Assembly);
             });
 
             // Init the database

--- a/ViewModels/SimpleDeviceViewModel.cs
+++ b/ViewModels/SimpleDeviceViewModel.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using CQRSTest.AutoMapper;
 
 public class SimpleDeviceViewModel
 {
@@ -7,6 +8,10 @@ public class SimpleDeviceViewModel
     public string Name { get; set; }
 
     public string DeviceTypeName { get; set; }
+
+    public string SecureContent { get; set; }
+
+    public bool RequiresConfiguration { get; set; }
 }
 
 public class SimpleDeviceViewModelProfile : Profile
@@ -14,6 +19,13 @@ public class SimpleDeviceViewModelProfile : Profile
     public SimpleDeviceViewModelProfile()
     {
         CreateMap<Device, SimpleDeviceViewModel>()
-            .ForMember(dto => dto.DeviceTypeName, conf => conf.MapFrom(ol => ol.DeviceType.Name));
+            .ForMember(dto => dto.DeviceTypeName, conf => conf.MapFrom(ol => ol.DeviceType.Name))
+            .ForMember(dto => dto.RequiresConfiguration, conf => conf.MapFrom(ol => ol.DeviceType.FunctionalConfiguration != Configuration.NotSupported || ol.DeviceType.TechnicalConfiguration != Configuration.NotSupported))
+            .ForMember(dto => dto.SecureContent, conf => conf.MapFrom(ol => ol.DeviceType.SecureContent));
+
+        // Decryption mapping, could also be used for doing translations on enums or whatever value conversions that are not supported in Expressions
+        CreateMap<SimpleDeviceViewModel, SimpleDeviceViewModel>()
+            .ForMember(dto => dto.SecureContent, conf => conf.ConvertUsing<SecureValueConverter, string>());
     }
 }
+

--- a/ViewModels/SimpleDeviceViewModel.cs
+++ b/ViewModels/SimpleDeviceViewModel.cs
@@ -1,15 +1,19 @@
 using AutoMapper;
-using MediatR;
-using System.Threading.Tasks;
 
-public record SimpleDeviceViewModel(int Id, string Name, string DeviceTypeName)
+public class SimpleDeviceViewModel
 {
-    public static async Task<SimpleDeviceViewModel> Load(IMediator mediator, int id)
-    {
-        var mapping = new MapperConfiguration(cfg =>
-            cfg.CreateMap<Device, SimpleDeviceViewModel>()
-            .ForMember(dto => dto.DeviceTypeName, conf => conf.MapFrom(ol => ol.DeviceType.Name)));
+    public int Id { get; set; }
 
-        return await mediator.Send(new DeviceGetByIdRequest<SimpleDeviceViewModel>(id, mapping));
+    public string Name { get; set; }
+
+    public string DeviceTypeName { get; set; }
+}
+
+public class SimpleDeviceViewModelProfile : Profile
+{
+    public SimpleDeviceViewModelProfile()
+    {
+        CreateMap<Device, SimpleDeviceViewModel>()
+            .ForMember(dto => dto.DeviceTypeName, conf => conf.MapFrom(ol => ol.DeviceType.Name));
     }
 }


### PR DESCRIPTION
In general, this follows the basic principle of the code created by tomkluskens in #1 

This option is much closer to a clean mediatr / automapper solution, it retains the Projection which was considered a powerfull feature of the original example, but removes the custom factory pattern around the viewmodel, making it more obvious what is actually happening. 